### PR TITLE
Add support for Azure, OpenAI, Palm, Anthropic, Cohere, Replicate Models - using litellm

### DIFF
--- a/factool/utils/claim_extractor.py
+++ b/factool/utils/claim_extractor.py
@@ -6,6 +6,7 @@ import json
 import asyncio
 from tqdm import tqdm
 from factool.env_config import factool_env_config
+from litellm import completion
 
 
 # env
@@ -26,7 +27,7 @@ config = {
 # Make api calls asynchronously
 async def run_api(messages):
     async def single_run(message):
-        output = openai.ChatCompletion.create(
+        output = completion(
             model=config['model_name'],
             messages=message,
             max_tokens=config['max_tokens'],

--- a/factool/utils/openai_wrapper.py
+++ b/factool/utils/openai_wrapper.py
@@ -11,6 +11,7 @@ import asyncio
 from typing import Any, List
 import os
 import pathlib
+from litellm import acompletion
 
 
 from factool.env_config import factool_env_config
@@ -27,6 +28,7 @@ class OpenAIChat():
             top_p=1,
             request_timeout=60,
     ):
+        # TODO: modify this to allow Anthropic, Claude, etc
         if 'gpt' not in model_name:
             openai.api_base = "http://localhost:8000/v1"
         self.config = {
@@ -64,7 +66,7 @@ class OpenAIChat():
         async def _request_with_retry(messages, retry=3):
             for _ in range(retry):
                 try:
-                    response = await openai.ChatCompletion.acreate(
+                    response = await acompletion(
                         model=self.config['model_name'],
                         messages=messages,
                         max_tokens=self.config['max_tokens'],

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ packages = find:
 include_package_data = True
 install_requires =
     openai==0.27.8
+    litellm==0.1.232
     PyYAML==6.0
     asyncio==3.4.3
     numpy


### PR DESCRIPTION
This PR adds support for models from all the above mentioned providers using https://github.com/BerriAI/litellm

Here's a sample of how it's used:

```
from litellm import completion, acompletion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# async openai
response = acompletion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```